### PR TITLE
Fix ModuleNotFoundError in compiled Windows executable

### DIFF
--- a/src/util/main.py
+++ b/src/util/main.py
@@ -1,4 +1,14 @@
 import os, sys, json
+if getattr(sys, 'frozen', False):
+    # If the application is run as a bundle, the PyInstaller bootloader
+    # extends the sys module by a flag frozen=True and sets the app
+    # path into variable _MEIPASS'.
+    application_path = sys._MEIPASS
+    sys.path.insert(0, application_path)
+else:
+    application_path = os.path.dirname(os.path.abspath(__file__))
+    sys.path.insert(0, os.path.abspath(os.path.join(application_path, '..', '..')))
+
 from PyQt5.QtWidgets import QApplication, QMainWindow, QWidget, QVBoxLayout, QLabel, QHBoxLayout, QTabWidget, QStatusBar
 import logging
 from util.logging_config import setup_logging


### PR DESCRIPTION
This commit fixes a `ModuleNotFoundError` that occurred when running the compiled Windows executable.

The issue was caused by the bundled application not being able to find the `util` module at runtime.

The fix involves adding code to the beginning of `src/util/main.py` to dynamically modify `sys.path`. The code checks if the application is running from a PyInstaller bundle (using `sys.frozen`) and sets the python path accordingly. This ensures that all modules are found correctly in both development and bundled environments.