### PR TITLE
Fix ModuleNotFoundError for good

### DIFF
--- a/src/util/main.py
+++ b/src/util/main.py
@@ -1,14 +1,21 @@
 import os, sys, json
+if getattr(sys, 'frozen', False):
+    application_path = sys._MEIPASS
+    sys.path.insert(0, application_path)
+else:
+    application_path = os.path.dirname(os.path.abspath(__file__))
+    sys.path.insert(0, os.path.abspath(os.path.join(application_path, '..', '..')))
+
 from PyQt5.QtWidgets import QApplication, QMainWindow, QWidget, QVBoxLayout, QLabel, QHBoxLayout, QTabWidget, QStatusBar
 import logging
-from util.logging_config import setup_logging
+from src.util.logging_config import setup_logging
 
 setup_logging()
 log = logging.getLogger(__name__)
 log.info("CyberRecon starting…")
 from PyQt5.QtGui import QPalette, QColor, QIcon
 from PyQt5.QtCore import Qt
-from util.addon_loader import discover_addons
+from src.util.addon_loader import discover_addons
 import os
 
 def load_cfg():


### PR DESCRIPTION
This commit provides the definitive fix for the `ModuleNotFoundError` that occurred in both the development and compiled environments.

The root cause was a combination of missing `__init__.py` files and incorrect import paths.

The following changes have been made:
- Created empty `__init__.py` files in `src/`, `src/util/`, `addons/`, and `addons/modules/` to define them as Python packages.
- Re-introduced the `sys.path` modification to `src/util/main.py` to correctly handle the Python path in both development and bundled (PyInstaller) environments.
- Changed the local imports in `src/util/main.py` to be absolute from the project root (e.g., `from src.util.logging_config import setup_logging`).

These changes establish a robust and correct package structure, ensuring that modules are imported correctly and permanently resolving the `ModuleNotFoundError`.