### PR TITLE
Fix run script errors and dependency issues

### DIFF
--- a/scripts/linux/run_dev.sh
+++ b/scripts/linux/run_dev.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -e
-export PYTHONPATH=$(dirname "$0")/../../src
 export QT_QPA_PLATFORM=offscreen
 python3 -m pip install -r "$(dirname "$0")/../../requirements.txt"
-python3 -m util.main
+python3 "$(dirname "$0")/../../main_launcher.py"

--- a/scripts/windows/run_dev.bat
+++ b/scripts/windows/run_dev.bat
@@ -1,4 +1,5 @@
 @echo off
-set PYTHONPATH=..\..\src
+setlocal
+python -m pip install --upgrade pip
 python -m pip install -r ..\..\requirements.txt
-python -m util.main
+python ..\..\main_launcher.py


### PR DESCRIPTION
This commit fixes several issues related to running the application in a development environment and handling dependencies.

The following changes have been made:
- Updated the `scripts/windows/run_dev.bat` and `scripts/linux/run_dev.sh` scripts to use the `main_launcher.py` script. This ensures that the Python path is set up correctly and resolves the `ModuleNotFoundError: No module named 'src'`.
- Verified that the `requirements.txt` file contains only the necessary packages (`PyQt5` and `psutil`). The `pybluez` package, which was causing installation errors for the user, is not part of this project's dependencies.